### PR TITLE
Changed paths for models

### DIFF
--- a/src/alexa-schema.js
+++ b/src/alexa-schema.js
@@ -300,7 +300,7 @@ class alexaSchema {
         const name = invocation.invocationname;
         const interactionModel = { languageModel: { invocationName: name, intents, types }};
 
-        const promise = fs.outputFile(path.join(customPathLocale, 'alexa', this.locale,`${_.kebabCase(name)}-${invocation.environment}-model.json`),  JSON.stringify({ interactionModel }, null, 2), { flag: 'w' });
+        const promise = fs.outputFile(path.join(customPathLocale, 'alexa', this.locale,`${invocation.environment}-model.json`),  JSON.stringify({ interactionModel }, null, 2), { flag: 'w' });
         promises.push(promise);
 
       });


### PR DESCRIPTION
The previous path made a bit harder to automate stuff cause it was required to now not only the LOCALE and environment but also the invocation name and how that got kebabCased

Example

```sh
speech-assets/
└── alexa
    ├── de-DE
    │   ├── prufung-local-local-model.json
    │   ├── prufung-production-model.json
    │   └── prufung-staging-staging-model.json
    ├── en-US
    │   ├── quiz-local-local-model.json
    │   ├── quiz-production-model.json
    │   └── quiz-staging-staging-model.json
    ├── local-skill.json
    ├── production-skill.json
    └── staging-skill.json
```

Now file names don't depend on the skill name

```sh
speech-assets/
└── alexa
    ├── de-DE
    │   ├── local-model.json
    │   ├── production-model.json
    │   └── staging-model.json
    ├── en-US
    │   ├── local-model.json
    │   ├── production-model.json
    │   └── staging-model.json
    ├── local-skill.json
    ├── production-skill.json
    └── staging-skill.json
```