### PR TITLE
Add multilanguage support for DialogFlow entries and usersays

### DIFF
--- a/src/csv-processor.js
+++ b/src/csv-processor.js
@@ -370,8 +370,21 @@ module.exports = (spreadsheetId, creds, othersToDownload, type) => {
   return getWorksheets(spreadsheetId, creds)
   .then((info) => {
     const title = info.title;
-    locale = AlexaSchema.VALID_LOCALES.find(loc => _.includes(title, loc) || _.includes(title, _.toLower(loc)));
-    locale = locale || AlexaSchema.VALID_LOCALES[0];
+    let validLocales = null;
+
+    switch(type) {
+      case 'dialogFlow':
+        validLocales = DialogFlowSchema.VALID_LOCALES;
+        break;
+      case 'cortana':
+        validLocales = CortanaSchema.VALID_LOCALES;
+        break;
+      default:
+        validLocales = AlexaSchema.VALID_LOCALES;
+    }
+
+    locale = validLocales.find(loc => _.includes(title, loc) || _.includes(title, _.toLower(loc)));
+    locale = locale || validLocales[0];
     return info.worksheets;
   })
   .then((worksheets) => {

--- a/src/dialog-flow-schema.js
+++ b/src/dialog-flow-schema.js
@@ -76,6 +76,10 @@ class dialogFlow {
     const customPathLocale = unique ? pathSpeech : path.join(pathSpeech);
     const promises = [];
     var tokenRegx = /{([^}]+)}/g;
+    const filePrefix = _.chain(this.locale)
+      .split('-')
+      .first()
+      .value();
 
     const includedIntents = _.filter(this.intents, (intent => _.isEmpty(intent.platformIntent) || _.includes(intent.platformIntent, 'dialogFlow')));
     this.intents = _.map(this.intents, (intent) => {
@@ -104,7 +108,7 @@ class dialogFlow {
         })
         .flattenDeep()
         .value();
-        const eachUtterancePromise = fs.outputFile(path.join(customPathLocale, 'dialog-flow', invocation.environment, 'entities', `${key}_entries_en.json`), JSON.stringify(str, null, 2), { flag: 'w' });
+        const eachUtterancePromise = fs.outputFile(path.join(customPathLocale, 'dialog-flow', invocation.environment, 'entities', `${key}_entries_${filePrefix}.json`), JSON.stringify(str, null, 2), { flag: 'w' });
         const entityDefinition = {
           name: key,
           isOverridable: true,
@@ -155,7 +159,7 @@ class dialogFlow {
 
           return ({ data, isTemplate: false, count: 0, updated: 0 });
         });
-        const eachUtterancePromise = fs.outputFile(path.join(customPathLocale, 'dialog-flow', invocation.environment, 'intents', `${key}_usersays_en.json`), JSON.stringify(str, null, 2), { flag: 'w' });
+        const eachUtterancePromise = fs.outputFile(path.join(customPathLocale, 'dialog-flow', invocation.environment, 'intents', `${key}_usersays_${filePrefix}.json`), JSON.stringify(str, null, 2), { flag: 'w' });
         promises.push(eachUtterancePromise);
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -330,9 +330,10 @@ form-data@~2.3.1:
     combined-stream "1.0.6"
     mime-types "^2.1.12"
 
-fs-extra@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"


### PR DESCRIPTION
So far the tool creates Dialogflow usersays and entries only supporting English locales, for example **YesIntent_usersays_en.json**. This commit adds support for creating multilingual files for Dialogflow, for example if the spreadsheet's name is **Utterances-nl-NL**, then the tool will create this instead **YesIntent_usersays_nl.json** (already tested).